### PR TITLE
Deprecate opal-observations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Observations plugin for Opal
 
+! Important Notice !
+This plugin is no longer actively maintiained
+
 Record patient observations (BP/Sp02/RR/ et cetera) and visualise trends over time in Opal.
 
 [![Build Status](https://travis-ci.org/openhealthcare/opal-observations.svg?branch=v0.5.0)](https://travis-ci.org/openhealthcare/opal-observations)


### PR DESCRIPTION
Deprecate the package with the same notice as our other deprecated packages.